### PR TITLE
fix VC++ warning warning C4244

### DIFF
--- a/src/plugins/hex_memory/hex_memory_plugin.cpp
+++ b/src/plugins/hex_memory/hex_memory_plugin.cpp
@@ -178,8 +178,8 @@ static void updateMemory(HexMemoryData* userData, PDReader* reader)
 
     free(userData->data);
 
-    userData->data = (unsigned char*)malloc(size);
-    memcpy(userData->data, data, size);
+    userData->data = (unsigned char*)malloc((size_t)size);
+    memcpy(userData->data, data, (size_t)size);
 
     printf("updating data %p %d\n", userData->data, (int)size);
 


### PR DESCRIPTION
explicit cast to size_t inorder to silence VC++ warning C4244
