### PR TITLE
Compile and link fixes for Linux (Ubuntu 14.10 x64).

### DIFF
--- a/src/prodbg/ui/ui_sc_editor.cpp
+++ b/src/prodbg/ui/ui_sc_editor.cpp
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <algorithm>
+#include <cstring>
 #include <map>
 #include <vector>
 #include <string>

--- a/units.libs.lua
+++ b/units.libs.lua
@@ -204,7 +204,8 @@ StaticLibrary {
 		},
 
         CXXOPTS = {
-        	{ "-DSCI_LEXER", "-Wno-everything", "-Wno-missing-braces" ; Config = { "macosx-*-*", "macosx_test-*", "linux-*-*" } },
+        	{ "-DSCI_LEXER", "-Wno-everything", "-Wno-missing-braces" ; Config = { "macosx-*-*", "macosx_test-*" } },
+        	{ "-DGTK -DSCI_LEXER", "-Wno-everything", "-Wno-missing-braces" ; Config = { "linux-*-*" } },
         	{ "/DSCI_LEXER", "/wd4267", "/wd4706", "/wd4244", "/wd4701", "/wd4334", "/wd4127"; Config = "win64-*-*" },
         },
     },

--- a/units.tests.lua
+++ b/units.tests.lua
@@ -32,7 +32,10 @@ local function Test(params)
 
 		Depends = params.Depends, 
 
-		Libs = { { "Ws2_32.lib", "shell32.lib", "psapi.lib", "iphlpapi.lib", "wsock32.lib", "kernel32.lib", "user32.lib", "gdi32.lib", "Comdlg32.lib", "Advapi32.lib" ; Config = { "win32-*-*", "win64-*-*" } } },
+		Libs = {
+			{ "Ws2_32.lib", "shell32.lib", "psapi.lib", "iphlpapi.lib", "wsock32.lib", "kernel32.lib", "user32.lib", "gdi32.lib", "Comdlg32.lib", "Advapi32.lib" ; Config = { "win32-*-*", "win64-*-*" } },
+			{ "X11", "GL" ; Config = { "linux-*-*" } },
+		},
 
 		Frameworks = { "Cocoa"  },
 


### PR DESCRIPTION
Compilation and linking fixes for Linux (Ubuntu 14.10 x4):
 * Use -DGTK for Scintilla Linux build - see https://github.com/emoon/ProDBG/blob/master/src/external/scintilla/include/Platform.h#L12 and https://github.com/emoon/ProDBG/blob/master/src/external/scintilla/include/Platform.h#L49, doesn't actually seem to need GTK though
 * Added include cstring for missing memmove in Scintilla SplitVector.hpp, Scintilla doesn't appear to include this in the header that uses it
 * Add missing libraries needed to link UI tests, on Linux it would probably be better to use pkg-config, but I don't know how to do this with tundra

All the tests appear to pass. ProDBG doesn't appear to draw anything though.