### PR TITLE
Added filters to file monitor

### DIFF
--- a/src/prodbg/core/file_monitor.cpp
+++ b/src/prodbg/core/file_monitor.cpp
@@ -3,6 +3,7 @@
 #include <foundation/array.h>
 #include <foundation/event.h>
 #include <foundation/fs.h>
+#include <foundation/path.h>
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -91,8 +92,9 @@ static void updateCallbacks(event_t* event)
 
 		    bool matching_filter = false;		
 		    for (int filter_index = 0; filter_index < filter_count; ++filter_index)
-		    {		    
-			found = strstr((char *)filename, filter_extensions[filter_index]);
+		    {
+			char *extension = path_file_extension(filename);
+			found = strstr(extension, filter_extensions[filter_index]);
 			if (found)
 			{
 			    matching_filter = true;

--- a/src/prodbg/core/file_monitor.cpp
+++ b/src/prodbg/core/file_monitor.cpp
@@ -57,12 +57,52 @@ static void updateCallbacks(event_t* event)
 	{
 		FileNotificationData* noteData = &s_notficationData[i];
 
-		// TODO: handle file filters
-
 		if (!strstr(filename, noteData->path))
 			continue;
 
-		noteData->callback(noteData->userData, filename, event->id);
+		if (strcmp(noteData->fileFilters, "*") == 0)
+		{
+		    noteData->callback(noteData->userData, filename, event->id);
+		}
+		else
+		{
+		    int filter_count = 1;
+		    char file_filters[strlen(noteData->fileFilters) + 1];
+		    strcpy(file_filters, noteData->fileFilters);
+		    const char* delimiter = ";"; 
+		    char* found;		
+		    found = strpbrk(file_filters, delimiter);
+		
+		    while (found != NULL)
+		    {
+			++filter_count;
+			found = strpbrk(found+1, delimiter);
+		    }		    
+
+		    // NOTE(marco): we could probably lower the string length
+		    char filter_extensions[filter_count][256];
+		    found = strtok(file_filters, delimiter);
+		    int current_filter = 0;
+		    while (found != NULL)
+		    {		    
+			strcpy(filter_extensions[current_filter++], found);
+			found = strtok(NULL, delimiter);
+		    }		
+
+		    bool matching_filter = false;		
+		    for (int filter_index = 0; filter_index < filter_count; ++filter_index)
+		    {		    
+			found = strstr((char *)filename, filter_extensions[filter_index]);
+			if (found)
+			{
+			    matching_filter = true;
+			    break;
+			}
+		    }
+
+		    if (matching_filter)
+			noteData->callback(noteData->userData, filename, event->id);
+		}
 	}
 }
 

--- a/src/prodbg/tests/core_tests.cpp
+++ b/src/prodbg/tests/core_tests.cpp
@@ -242,8 +242,8 @@ void test_file_notification(void**)
 	const char* test_dir = "t2-output/test_dir"; 
 	const char* test_dir_2 = "t2-output/2_test_dir"; 
 	const char* filename_2 = "t2-output/test_dir/test_file_2";
-	s_filename = "t2-output/test_dir/test_file";
-	s_filename_2 = "t2-output/2_test_dir/test_file";
+	s_filename = "t2-output/test_dir/test_file.dll";
+	s_filename_2 = "t2-output/2_test_dir/test_file.txt";
 
 	fs_remove_directory(test_dir); 
 	fs_make_directory(test_dir);
@@ -282,7 +282,7 @@ void test_file_notification(void**)
 
 	assert_int_equal(s_checkPhase, 2);
 
-	FileMonitor_addPath(test_dir_2, "*", fileNotifaction2, &s_userData_2);
+	FileMonitor_addPath(test_dir_2, "txt", fileNotifaction2, &s_userData_2);
 
 	thread_sleep(1000);
 


### PR DESCRIPTION
The implementation is pretty simple: filters should be separated by ";" and "*" is used as wildcard. I tried to be careful with memory allocation for the strings, but I might have made some silly mistake. Let me know if that's the case and I will correct it! Also, let me know if you have any further suggestion/comment.