### PR TITLE
fix(cfixed_string): Convert to enum

### DIFF
--- a/api/rust/prodbg/src/cfixed_string.rs
+++ b/api/rust/prodbg/src/cfixed_string.rs
@@ -1,129 +1,200 @@
-use std::ffi::CString;
+use std::borrow::{Borrow, Cow};
+use std::ffi::{CStr, CString};
 use std::mem;
+use std::ops;
+use std::os::raw::c_char;
 use std::ptr;
 
 const STRING_SIZE: usize = 512;
 
-pub struct CFixedString {
-    pub local_string: [i8; STRING_SIZE],
-    pub heap_string: Option<CString>,
+/// This is a C String abstractions that presents a CStr like
+/// interface for interop purposes but tries to be little nicer
+/// by avoiding heap allocations if the string is within the
+/// generous bounds (512 bytes) of the statically sized buffer.
+/// Strings over this limit will be heap allocated, but the
+/// interface outside of this abstraction remains the same.
+pub enum CFixedString {
+    Local([c_char; STRING_SIZE]),
+    Heap(CString),
 }
 
 impl CFixedString {
-    pub fn from_str(name: &str) -> CFixedString {
-        unsafe {
-            let name_len = name.len();
-            if name_len <= STRING_SIZE - 1 {
-                let mut handler = CFixedString {
-                    local_string: mem::uninitialized(),
-                    heap_string: None,
-                };
+    pub fn from_str(s: &str) -> Self {
+        Self::from(s)
+    }
 
-                ptr::copy(name.as_ptr(),
-                          handler.local_string.as_mut_ptr() as *mut u8,
-                          name_len);
-                handler.local_string[name_len] = 0;
+    pub fn as_ptr(&self) -> *const c_char {
+        match *self {
+            CFixedString::Local(ref s) => s.as_ptr(),
+            CFixedString::Heap(ref s) => s.as_ptr(),
+        }
+    }
 
-                handler
-            } else {
-                CFixedString {
-                    local_string: mem::uninitialized(),
-                    heap_string: Some(CString::new(name).unwrap()),
+    /// Returns true if the string has been heap allocated
+    pub fn is_allocated(&self) -> bool {
+        match *self {
+            CFixedString::Local(_) => false,
+            _ => true,
+        }
+    }
+
+    /// Converts a `CFixedString` into a `Cow<str>`.
+    ///
+    /// This function will calculate the length of this string (which normally
+    /// requires a linear amount of work to be done) and then return the
+    /// resulting slice as a `Cow<str>`, replacing any invalid UTF-8 sequences
+    /// with `U+FFFD REPLACEMENT CHARACTER`. If there are no invalid UTF-8
+    /// sequences, this will merely return a borrowed slice.
+    pub fn to_string(&self) -> Cow<str> {
+        String::from_utf8_lossy(&self.to_bytes())
+    }
+}
+
+impl<'a> From<&'a str> for CFixedString {
+    fn from(s: &'a str) -> Self {
+        match s.len() {
+            len if len <= STRING_SIZE - 1 => unsafe {
+                let mut ret = CFixedString::Local(mem::uninitialized());
+
+                match ret {
+                    CFixedString::Local(ref mut l) => {
+                        let ptr = l.as_mut_ptr() as *mut u8;
+                        ptr::copy(s.as_ptr(), ptr, len);
+                        *ptr.offset(len as isize) = 0;
+                    },
+                    _ => unreachable!(),
                 }
-            }
-        }
-    }
 
-    pub fn as_ptr(&mut self) -> *const i8 {
-        if self.heap_string == None {
-            self.local_string.as_ptr()
-        } else {
-            self.heap_string.as_mut().unwrap().as_ptr()
+                ret
+            },
+            _ => CFixedString::Heap(CString::new(s).unwrap()),
         }
     }
+}
+
+impl From<CFixedString> for String {
+    fn from(s: CFixedString) -> Self {
+        String::from_utf8_lossy(&s.to_bytes()).into_owned()
+    }
+}
+
+impl ops::Deref for CFixedString {
+    type Target = CStr;
+
+    fn deref(&self) -> &CStr {
+        match *self {
+            CFixedString::Local(ref s) => unsafe { CStr::from_ptr(s.as_ptr()) },
+            CFixedString::Heap(ref s) => s,
+        }
+    }
+}
+
+impl Borrow<CStr> for CFixedString {
+    fn borrow(&self) -> &CStr { self }
+}
+
+impl AsRef<CStr> for CFixedString {
+    fn as_ref(&self) -> &CStr { self }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::CStr;
     use super::*;
 
-    fn get_string(handler: &mut CFixedString) -> String {
-        unsafe { CStr::from_ptr(handler.as_ptr()).to_string_lossy().into_owned() }
+    fn gen_string(len: usize) -> String {
+        use std::fmt::Write;
+
+        let mut out = String::with_capacity(len);
+
+        for _ in 0..len / 16 {
+            out.write_str("zyxvutabcdef9876").unwrap();
+        }
+
+        for i in 0..len % 16 {
+            out.write_char((i as u8 + 'A' as u8) as char).unwrap();
+        }
+
+        assert_eq!(out.len(), len);
+        out
     }
 
     #[test]
     fn test_empty_handler() {
         let short_string = "";
-        let mut t = CFixedString::from_str(short_string);
-        assert_eq!(t.heap_string.is_none(), true);
-        assert_eq!(get_string(&mut t), short_string);
-    }
 
+        let t = CFixedString::from_str(short_string);
+
+        assert!(!t.is_allocated());
+        assert_eq!(&t.to_string(), short_string);
+    }
 
     #[test]
     fn test_short_1() {
         let short_string = "test_local";
-        let mut t = CFixedString::from_str(short_string);
-        assert_eq!(t.heap_string.is_none(), true);
-        assert_eq!(get_string(&mut t), short_string);
+
+        let t = CFixedString::from_str(short_string);
+
+        assert!(!t.is_allocated());
+        assert_eq!(&t.to_string(), short_string);
     }
 
     #[test]
     fn test_short_2() {
         let short_string = "test_local stoheusthsotheost";
-        let mut t = CFixedString::from_str(short_string);
-        assert_eq!(t.heap_string.is_none(), true);
-        assert_eq!(get_string(&mut t), short_string);
+
+        let t = CFixedString::from_str(short_string);
+
+        assert!(!t.is_allocated());
+        assert_eq!(&t.to_string(), short_string);
     }
 
     #[test]
     fn test_511() {
         // this string (width 511) buffer should just fit
-        let test_511_string = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeuuuuuuuuuuuuu\
-                                uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu\
-                                uuuueeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeaaaaaaaaaaaa\
-                                aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaoooooooooooooooooooooooooooooo\
-                                oooooooooooooooooooooooooooooooooeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
-                                eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeuuuuuuuuuuuuuuuuuuuuuuuuuu\
-                                uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuoooooooooooooooooooooooooooooo\
-                                oooooooooooooooooooooooooooooooooooooooacd";
-        let mut t = CFixedString::from_str(test_511_string);
-        assert_eq!(t.heap_string.is_none(), true);
-        assert_eq!(get_string(&mut t), test_511_string);
+        let test_511_string = gen_string(511);
+
+        let t = CFixedString::from_str(&test_511_string);
+
+        assert!(!t.is_allocated());
+        assert_eq!(&t.to_string(), &test_511_string);
     }
 
     #[test]
     fn test_512() {
         // this string (width 512) buffer should not fit
-        let test_512_string = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeuuuuuuuuuuuuu\
-                                uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu\
-                                uuuueeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeaaaaaaaaaaaa\
-                                aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaoooooooooooooooooooooooooooooo\
-                                oooooooooooooooooooooooooooooooooeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
-                                eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeuuuuuuuuuuuuuuuuuuuuuuuuuu\
-                                uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuoooooooooooooooooooooooooooooo\
-                                oooooooooooooooooooooooooooooooooooooooabcd";
-        let mut t = CFixedString::from_str(test_512_string);
-        assert_eq!(t.heap_string.is_some(), true);
-        assert_eq!(get_string(&mut t), test_512_string);
+        let test_512_string = gen_string(512);
+
+        let t = CFixedString::from_str(&test_512_string);
+
+        assert!(t.is_allocated());
+        assert_eq!(&t.to_string(), &test_512_string);
     }
 
     #[test]
     fn test_513() {
         // this string (width 513) buffer should not fit
-        let test_513_string = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeuuuuuuuuuuuuu\
-                                uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu\
-                                uuuueeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeaaaaaaaaaaaa\
-                                aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaoooooooooooooooooooooooooooooo\
-                                oooooooooooooooooooooooooooooooooeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
-                                eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeuuuuuuuuuuuuuuuuuuuuuuuuuu\
-                                uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuoooooooooooooooooooooooooooooo\
-                                ooooooooooooooooooooooooooooooooooooooooabcd";
-        let mut t = CFixedString::from_str(test_513_string);
-        assert_eq!(t.heap_string.is_some(), true);
-        assert_eq!(get_string(&mut t), test_513_string);
+        let test_513_string = gen_string(513);
+
+        let t = CFixedString::from_str(&test_513_string);
+
+        assert!(t.is_allocated());
+        assert_eq!(&t.to_string(), &test_513_string);
+    }
+
+    #[test]
+    fn test_to_owned() {
+        let short = "this is an amazing string";
+
+        let t = CFixedString::from_str(short);
+
+        assert!(!t.is_allocated());
+        assert_eq!(&String::from(t), short);
+
+        let long = gen_string(1025);
+
+        let t = CFixedString::from_str(&long);
+
+        assert!(t.is_allocated());
+        assert_eq!(&String::from(t), &long);
     }
 }
-
-

--- a/api/rust/prodbg/src/menu_service.rs
+++ b/api/rust/prodbg/src/menu_service.rs
@@ -30,7 +30,7 @@ pub struct MenuFuncs {
 
 impl MenuFuncs {
     pub fn create_menu(&mut self, name: &str) -> *mut c_void {
-        let mut title = CFixedString::from_str(name);
+        let title = CFixedString::from_str(name);
         unsafe {
             let data = (*self.api).private_data;
             ((*self.api).create_menu)(data, title.as_ptr())
@@ -53,7 +53,7 @@ impl MenuFuncs {
                          -> PDMenuItem {
         unsafe {
             let data = (*self.api).private_data;
-            let mut title = CFixedString::from_str(name);
+            let title = CFixedString::from_str(name);
             ((*self.api).add_menu_item)(data, item, title.as_ptr(), id as c_uint, key, modifier)
         }
     }


### PR DESCRIPTION
Improved ergonomics of working with CFixedString by changing
it to an enum instead of a struct, and implemented various traits
to let be used in interop, as well  as converting it to a String/&str.