### PR TITLE
Fix for issue #152 (stuck source code view)

### DIFF
--- a/api/include/pd_ui.h
+++ b/api/include/pd_ui.h
@@ -517,8 +517,8 @@ typedef struct PDUI {
 #define PDUI_button_size(uiFuncs, label, w, h) uiFuncs->button(label, w, h)
 
 #define PDUI_sc_send_command(funcs, msg, p0, p1) funcs->send_command(funcs->private_data, msg, p0, p1)
-#define PDUI_sc_draw(funcs) funcs->update(funcs->private_data)
-#define PDUI_sc_update(funcs) funcs->draw(funcs->private_data)
+#define PDUI_sc_draw(funcs) funcs->draw(funcs->private_data)
+#define PDUI_sc_update(funcs) funcs->update(funcs->private_data)
 
 #define PDUI_set_title(funcs, title) funcs->set_title(funcs->private_data, title)
 

--- a/src/native/ui/bgfx/imgui_extra.inl
+++ b/src/native/ui/bgfx/imgui_extra.inl
@@ -122,7 +122,8 @@ ImScEditor* ScInputText(const char* label, float xSize, float ySize, void (*call
 
     ScEditor_setDrawList(GetWindowDrawList());
     ScEditor_setFont(GetWindowFont());
-	ScEditor_setPos(0.0f, 14.0f);
+    // update Scintilla rendering position accordingly with position of the ImGui window
+	ScEditor_setPos(window->PosFloat.x, window->PosFloat.y + 14.0f);
 
 	//int currentPos = (int)editorInterface->SendCommand(SCN_GETTOPLINE, 0, 0);
 

--- a/src/native/ui/imgui_ffi.cpp
+++ b/src/native/ui/imgui_ffi.cpp
@@ -1574,7 +1574,7 @@ static void fill_rect(PDRect rect, PDColor color) {
 
 extern "C" int imgui_begin(const char* name, int show) {
 	bool s = !!show;
-    ImGui::Begin(name, &s, ImVec2(0, 0), true, ImGuiWindowFlags_NoCollapse);
+    ImGui::Begin(name, &s, ImVec2(0, 0), true, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove);
     return s;
 }
 

--- a/src/native/ui/imgui_ffi.cpp
+++ b/src/native/ui/imgui_ffi.cpp
@@ -35,14 +35,14 @@ static intptr_t scSendCommand(void* privData, unsigned int message, uintptr_t p0
 
 static void scUpdate(void* privData) {
     ImScEditor* editor = (ImScEditor*)privData;
-    editor->Draw();
+    editor->Update();
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 static void scDraw(void* privData) {
     ImScEditor* editor = (ImScEditor*)privData;
-    return editor->Update();
+    return editor->Draw();
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1574,7 +1574,7 @@ static void fill_rect(PDRect rect, PDColor color) {
 
 extern "C" int imgui_begin(const char* name, int show) {
 	bool s = !!show;
-    ImGui::Begin(name, &s, ImVec2(0, 0), true, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove);
+    ImGui::Begin(name, &s, ImVec2(0, 0), true, ImGuiWindowFlags_NoCollapse);
     return s;
 }
 


### PR DESCRIPTION
This fixes the broken position of sourcecode view plugin and also calls draw() and render() functions using correct naming.