### PR TITLE
Fix for #153 - update main window's context size on window size change

### DIFF
--- a/src/native/ui/bgfx/bgfx_plugin_ui.cpp
+++ b/src/native/ui/bgfx/bgfx_plugin_ui.cpp
@@ -294,14 +294,16 @@ extern "C" void prodbg_add_char(unsigned short c) {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-extern "C" void prodbg_set_window_size(int width, int height) {
+extern "C" void bgfx_set_window_size(int width, int height) {
     Context* context = &s_context;
 
-    context->width = width;
-    context->height = height;
+    if (context->width != width || context->height != height) {
+        context->width = width;
+        context->height = height;
 
-    bgfx::reset((uint32_t)width, (uint32_t)height);
-    imgui_update_size(width, height);
+        bgfx::reset((uint32_t)width, (uint32_t)height);
+        imgui_update_size(width, height);
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/prodbg/bgfx/src/lib.rs
+++ b/src/prodbg/bgfx/src/lib.rs
@@ -23,6 +23,10 @@ impl Bgfx {
         unsafe { bgfx_pre_update(); }
     }
 
+    pub fn update_window_size(&self, width: c_int, height: c_int) {
+        unsafe { bgfx_set_window_size(width, height); }
+    }
+
     pub fn post_update(&self) {
         unsafe { bgfx_post_update(); }
     }
@@ -77,6 +81,7 @@ extern "C" {
     fn bgfx_create();
     fn bgfx_create_window(window: *const c_void, width: c_int, height: c_int);
     fn bgfx_destroy();
+    fn bgfx_set_window_size(width: c_int, height: c_int);
 
     fn cursor_init();
     fn cursor_set_type(t: i32);

--- a/src/prodbg/bgfx/src/lib.rs
+++ b/src/prodbg/bgfx/src/lib.rs
@@ -23,7 +23,7 @@ impl Bgfx {
         unsafe { bgfx_pre_update(); }
     }
 
-    pub fn update_window_size(&self, width: c_int, height: c_int) {
+    pub fn update_window_size(width: c_int, height: c_int) {
         unsafe { bgfx_set_window_size(width, height); }
     }
 

--- a/src/prodbg/main/src/windows.rs
+++ b/src/prodbg/main/src/windows.rs
@@ -365,6 +365,9 @@ impl Window {
         let mut views_to_delete = Vec::new();
         let mut has_shown_menu = 0u32;
 
+        let win_size = self.win.get_size();
+        Bgfx::update_window_size(win_size.0 as i32, win_size.1 as i32);
+
         self.win.update();
         self.ws.update();
         self.update_key_state();

--- a/src/prodbg/ui_testbench/src/main.rs
+++ b/src/prodbg/ui_testbench/src/main.rs
@@ -125,6 +125,10 @@ fn main() {
         bgfx.post_update();
 
         window.update();
+
+        // update main window size if it was changed by user
+        let win_size = window.get_size();
+        bgfx.update_window_size(win_size.0 as i32, win_size.1 as i32);
     }
 
     //unsafe {

--- a/src/prodbg/ui_testbench/src/main.rs
+++ b/src/prodbg/ui_testbench/src/main.rs
@@ -128,7 +128,7 @@ fn main() {
 
         // update main window size if it was changed by user
         let win_size = window.get_size();
-        bgfx.update_window_size(win_size.0 as i32, win_size.1 as i32);
+        Bgfx::update_window_size(win_size.0 as i32, win_size.1 as i32);
     }
 
     //unsafe {


### PR DESCRIPTION
Updating window size is done by utilizing the unused prodbg_set_window_size() function (renamed for consistency to bgfx_*). Context size is updated only if it changed.