### PR TITLE
#178 - remove dependency on libc crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,16 +73,6 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "libc"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "libc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "libloading"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ name = "prodbg"
 
 [dependencies]
 notify = "^2.5.0"
-libc = "0.2.0"
 libloading = "0.2.0"
 
 # These are here to get

--- a/api/rust/prodbg/Cargo.lock
+++ b/api/rust/prodbg/Cargo.lock
@@ -31,11 +31,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "winapi"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/api/rust/prodbg/Cargo.toml
+++ b/api/rust/prodbg/Cargo.toml
@@ -7,6 +7,5 @@ authors = ["Daniel Collin <daniel@collin.com>"]
 gcc = "0.3.19"
 
 [dependencies]
-libc = "0.2"
 bitflags = "0.3"
 

--- a/api/rust/prodbg/src/backend.rs
+++ b/api/rust/prodbg/src/backend.rs
@@ -1,7 +1,6 @@
 use read_write::*;
 use service::*;
-use libc::*;
-//use std::os::raw;
+use std::os::raw::{c_uchar, c_int, c_void};
 use menu_service::{MenuFuncs, CMenuFuncs1};
 use std::mem::transmute;
 

--- a/api/rust/prodbg/src/dialogs.rs
+++ b/api/rust/prodbg/src/dialogs.rs
@@ -1,4 +1,4 @@
-use libc::{c_char, c_int};
+use std::os::raw::{c_char, c_int};
 use std::ffi::CString;
 
 #[repr(C)]

--- a/api/rust/prodbg/src/io.rs
+++ b/api/rust/prodbg/src/io.rs
@@ -1,4 +1,4 @@
-use libc::{c_void, c_char};
+use std::os::raw::{c_char, c_void};
 
 #[repr(C)]
 pub enum LoadState {

--- a/api/rust/prodbg/src/lib.rs
+++ b/api/rust/prodbg/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate libc;
-
 #[macro_use]
 extern crate bitflags;
 

--- a/api/rust/prodbg/src/menu_service.rs
+++ b/api/rust/prodbg/src/menu_service.rs
@@ -1,4 +1,4 @@
-use libc::{c_char, c_uint, c_void};
+use std::os::raw::{c_char, c_uint, c_void};
 use CFixedString;
 
 pub struct PDMenuHandle(pub u64);

--- a/api/rust/prodbg/src/message_service.rs
+++ b/api/rust/prodbg/src/message_service.rs
@@ -1,4 +1,4 @@
-use libc::c_char;
+use std::os::raw::c_char;
 use std::ffi::CString;
 
 #[repr(C)]

--- a/api/rust/prodbg/src/plugin_handler.rs
+++ b/api/rust/prodbg/src/plugin_handler.rs
@@ -1,6 +1,6 @@
-use libc::*;
 use backend::*;
 use view::*;
+use std::os::raw::{c_char, c_void};
 use std::mem::transmute;
 
 #[repr(C)]

--- a/api/rust/prodbg/src/read_write.rs
+++ b/api/rust/prodbg/src/read_write.rs
@@ -1,48 +1,48 @@
-use libc::*;
 use std::mem::transmute;
 use std::slice;
 use std::str;
+use std::os::raw::*;
 use CFixedString;
 
 #[repr(C)]
 pub struct CPDReaderAPI {
     pub data: *mut c_void,
-    pub read_get_event: extern fn(reader: *mut c_void) -> uint32_t,
+    pub read_get_event: extern fn(reader: *mut c_void) -> c_uint,
     pub read_iterator_next_event: extern fn(reader: *mut c_void,
-                                            it: *mut uint64_t) -> uint32_t,
-    pub read_iterator_begin: extern fn(reader: *mut c_void, it: *mut uint64_t,
-                                       keyName: *mut *const c_char, parentIt: uint64_t)
-                                    -> uint32_t,
+                                            it: *mut c_ulonglong) -> c_uint,
+    pub read_iterator_begin: extern fn(reader: *mut c_void, it: *mut c_ulonglong,
+                                       keyName: *mut *const c_char, parentIt: c_ulonglong)
+                                    -> c_uint,
     pub read_iterator_next: extern fn(reader: *mut c_void, keyName: *mut *const c_char,
-                                      it: *mut uint64_t) -> uint32_t,
-    pub read_next_entry: extern fn(reader: *mut c_void, arrayIt: *mut uint64_t)
-                                -> int32_t,
-    pub read_find_s8: extern fn(reader: *mut c_void, res: *mut int8_t, id: *const c_char,
-                                it: uint64_t) -> uint32_t,
-    pub read_find_u8: extern fn(reader: *mut c_void, res: *mut uint8_t, id: *const c_char,
-                                it: uint64_t) -> uint32_t,
-    pub read_find_s16: extern fn(reader: *mut c_void, res: *mut int16_t, id: *const c_char,
-                                 it: uint64_t) -> uint32_t,
-    pub read_find_u16: extern fn(reader: *mut c_void, res: *mut uint16_t, id: *const c_char,
-                                 it: uint64_t) -> uint32_t,
-    pub read_find_s32: extern fn(reader: *mut c_void, res: *mut int32_t, id: *const c_char,
-                                 it: uint64_t) -> uint32_t,
-    pub read_find_u32: extern fn(reader: *mut c_void, res: *mut uint32_t, id: *const c_char,
-                                 it: uint64_t) -> uint32_t,
-    pub read_find_s64: extern fn(reader: *mut c_void, res: *mut int64_t, id: *const c_char,
-                                 it: uint64_t) -> uint32_t,
-    pub read_find_u64: extern fn(reader: *mut c_void, res: *mut uint64_t, id: *const c_char,
-                                 it: uint64_t) -> uint32_t,
+                                      it: *mut c_ulonglong) -> c_uint,
+    pub read_next_entry: extern fn(reader: *mut c_void, arrayIt: *mut c_ulonglong)
+                                -> c_int,
+    pub read_find_s8: extern fn(reader: *mut c_void, res: *mut c_char, id: *const c_char,
+                                it: c_ulonglong) -> c_uint,
+    pub read_find_u8: extern fn(reader: *mut c_void, res: *mut c_uchar, id: *const c_char,
+                                it: c_ulonglong) -> c_uint,
+    pub read_find_s16: extern fn(reader: *mut c_void, res: *mut c_short, id: *const c_char,
+                                 it: c_ulonglong) -> c_uint,
+    pub read_find_u16: extern fn(reader: *mut c_void, res: *mut c_ushort, id: *const c_char,
+                                 it: c_ulonglong) -> c_uint,
+    pub read_find_s32: extern fn(reader: *mut c_void, res: *mut c_int, id: *const c_char,
+                                 it: c_ulonglong) -> c_uint,
+    pub read_find_u32: extern fn(reader: *mut c_void, res: *mut c_uint, id: *const c_char,
+                                 it: c_ulonglong) -> c_uint,
+    pub read_find_s64: extern fn(reader: *mut c_void, res: *mut c_longlong, id: *const c_char,
+                                 it: c_ulonglong) -> c_uint,
+    pub read_find_u64: extern fn(reader: *mut c_void, res: *mut c_ulonglong, id: *const c_char,
+                                 it: c_ulonglong) -> c_uint,
     pub read_find_float: extern fn(reader: *mut c_void, res: *mut c_float, id: *const c_char,
-                                   it: uint64_t) -> uint32_t,
+                                   it: c_ulonglong) -> c_uint,
     pub read_find_double: extern fn(reader: *mut c_void, res: *mut c_double, id: *const c_char,
-                                    it: uint64_t) -> uint32_t,
+                                    it: c_ulonglong) -> c_uint,
     pub read_find_string: extern fn(reader: *mut c_void, res: *mut *const c_char, id: *const c_char,
-                                    it: uint64_t) -> uint32_t,
-    pub read_find_data: extern fn(reader: *mut c_void, data: *mut *mut c_void, size: *mut uint64_t,
-                                  id: *const c_char, it: uint64_t) -> uint32_t,
-    pub read_find_array: extern fn(reader: *mut c_void, arrayIt: *mut uint64_t, id: *const c_char,
-                                   it: uint64_t) -> uint32_t,
+                                    it: c_ulonglong) -> c_uint,
+    pub read_find_data: extern fn(reader: *mut c_void, data: *mut *mut c_void, size: *mut c_ulonglong,
+                                  id: *const c_char, it: c_ulonglong) -> c_uint,
+    pub read_find_array: extern fn(reader: *mut c_void, arrayIt: *mut c_ulonglong, id: *const c_char,
+                                   it: c_ulonglong) -> c_uint,
     pub read_dump_data: extern fn(reader: *mut c_void),
 }
 
@@ -55,7 +55,7 @@ pub enum WriteStatus {
 #[repr(C)]
 pub struct CPDWriterAPI {
     private_data: *mut c_void,
-    pub write_event_begin: extern "C" fn(writer: *mut c_void, event: uint16_t) -> WriteStatus,
+    pub write_event_begin: extern "C" fn(writer: *mut c_void, event: c_ushort) -> WriteStatus,
     pub write_event_end: extern fn(writer: *mut c_void) -> WriteStatus,
     pub write_header_array_begin: extern fn(writer: *mut c_void, ids: *mut *const c_char)
                                          -> WriteStatus,
@@ -64,19 +64,19 @@ pub struct CPDWriterAPI {
     pub write_array_end: extern fn(writer: *mut c_void) -> WriteStatus,
     pub write_array_entry_begin: extern fn(writer: *mut c_void) -> WriteStatus,
     pub write_array_entry_end: extern fn(writer: *mut c_void) -> WriteStatus,
-    pub write_s8: extern fn(writer: *mut c_void, id: *const c_char, v: int8_t) -> WriteStatus,
-    pub write_u8: extern fn(writer: *mut c_void, id: *const c_char, v: uint8_t) -> WriteStatus,
-    pub write_s16: extern fn(writer: *mut c_void, id: *const c_char, v: int16_t) -> WriteStatus,
-    pub write_u16: extern fn(writer: *mut c_void, id: *const c_char, v: uint16_t) -> WriteStatus,
-    pub write_s32: extern fn(writer: *mut c_void, id: *const c_char, v: int32_t) -> WriteStatus,
-    pub write_u32: extern fn(writer: *mut c_void, id: *const c_char, v: uint32_t) -> WriteStatus,
-    pub write_s64: extern fn(writer: *mut c_void, id: *const c_char, v: int64_t) -> WriteStatus,
-    pub write_u64: extern fn(writer: *mut c_void, id: *const c_char, v: uint64_t) -> WriteStatus,
+    pub write_s8: extern fn(writer: *mut c_void, id: *const c_char, v: c_char) -> WriteStatus,
+    pub write_u8: extern fn(writer: *mut c_void, id: *const c_char, v: c_uchar) -> WriteStatus,
+    pub write_s16: extern fn(writer: *mut c_void, id: *const c_char, v: c_short) -> WriteStatus,
+    pub write_u16: extern fn(writer: *mut c_void, id: *const c_char, v: c_ushort) -> WriteStatus,
+    pub write_s32: extern fn(writer: *mut c_void, id: *const c_char, v: c_int) -> WriteStatus,
+    pub write_u32: extern fn(writer: *mut c_void, id: *const c_char, v: c_uint) -> WriteStatus,
+    pub write_s64: extern fn(writer: *mut c_void, id: *const c_char, v: c_longlong) -> WriteStatus,
+    pub write_u64: extern fn(writer: *mut c_void, id: *const c_char, v: c_ulonglong) -> WriteStatus,
     pub write_float: extern fn(writer: *mut c_void, id: *const c_char, v: c_float) -> WriteStatus,
     pub write_double: extern fn(writer: *mut c_void, id: *const c_char, v: c_double) -> WriteStatus,
     pub write_string: extern fn(writer: *mut c_void, id: *const c_char, v: *const c_char)
                              -> WriteStatus,
-    pub write_data: extern fn(w: *mut c_void, id: *const c_char, d: *const uint8_t, l: c_uint)
+    pub write_data: extern fn(w: *mut c_void, id: *const c_char, d: *const c_uchar, l: c_uint)
                             -> WriteStatus,
 }
 

--- a/api/rust/prodbg/src/service.rs
+++ b/api/rust/prodbg/src/service.rs
@@ -1,4 +1,4 @@
-use libc::{c_uchar, c_void};
+use std::os::raw::{c_uchar, c_void};
 use std::mem::transmute;
 
 use Capstone;

--- a/api/rust/prodbg/src/ui_ffi.rs
+++ b/api/rust/prodbg/src/ui_ffi.rs
@@ -2,7 +2,6 @@
 // Disable this warning until all code has been fixed
 #[allow(non_upper_case_globals)]
 
-extern crate libc;
 extern crate bitflags;
 
 use std::os::raw::{c_char, c_uchar, c_float, c_int, c_uint, c_ushort, c_void};

--- a/api/rust/prodbg/src/view.rs
+++ b/api/rust/prodbg/src/view.rs
@@ -2,7 +2,7 @@ use service::*;
 use read_write::*;
 use ui::*;
 use ui_ffi::*;
-use libc::{c_void, c_uchar};
+use std::os::raw::{c_uchar, c_void};
 use std::mem::transmute;
 use io::{CPDSaveState, CPDLoadState};
 

--- a/src/addons/amiga_uae_plugin/Cargo.lock
+++ b/src/addons/amiga_uae_plugin/Cargo.lock
@@ -3,7 +3,6 @@ name = "amiga_uae_plugin"
 version = "0.1.0"
 dependencies = [
  "gdb_remote 0.1.0",
- "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "prodbg_api 0.1.0",
 ]
 
@@ -25,16 +24,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "prodbg_api"
 version = "0.1.0"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/src/addons/amiga_uae_plugin/Cargo.toml
+++ b/src/addons/amiga_uae_plugin/Cargo.toml
@@ -8,6 +8,5 @@ name = "amiga_uae_plugin"
 crate-type = ["dylib"]
 
 [dependencies]
-libc = "0.2"
 prodbg_api = { path = "../../../api/rust/prodbg" }
 gdb_remote = { path = "../../crates/gdb-remote" }

--- a/src/addons/amiga_uae_plugin/src/lib.rs
+++ b/src/addons/amiga_uae_plugin/src/lib.rs
@@ -1,9 +1,8 @@
 #[macro_use]
 extern crate prodbg_api;
 extern crate gdb_remote;
-extern crate libc;
 use prodbg_api::*;
-use libc::c_void;
+use std::os::raw::{c_void};
 use gdb_remote::GdbRemote;
 
 struct AmigaUaeBackend {

--- a/src/plugins/bitmap_memory/Cargo.lock
+++ b/src/plugins/bitmap_memory/Cargo.lock
@@ -29,17 +29,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "prodbg_api"
 version = "0.1.0"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/plugins/disassembly/Cargo.lock
+++ b/src/plugins/disassembly/Cargo.lock
@@ -29,17 +29,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "prodbg_api"
 version = "0.1.0"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/prodbg/bgfx/Cargo.lock
+++ b/src/prodbg/bgfx/Cargo.lock
@@ -2,7 +2,6 @@
 name = "bgfx_rs"
 version = "0.1.0"
 dependencies = [
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "prodbg_api 0.1.0",
 ]
 
@@ -17,16 +16,10 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "libc"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "prodbg_api"
 version = "0.1.0"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/src/prodbg/bgfx/Cargo.toml
+++ b/src/prodbg/bgfx/Cargo.toml
@@ -4,6 +4,5 @@ version = "0.1.0"
 authors = ["Daniel Collin <daniel@collin.com>"]
 
 [dependencies]
-libc = "0.2"
 prodbg_api = { path = "../../../api/rust/prodbg" }
 

--- a/src/prodbg/bgfx/src/lib.rs
+++ b/src/prodbg/bgfx/src/lib.rs
@@ -1,7 +1,6 @@
 //extern crate prodbg_api;
-extern crate libc;
 
-use libc::{c_int, c_void};
+use std::os::raw::{c_int, c_void};
 
 pub struct Bgfx {
     pub temp: i32,

--- a/src/prodbg/core/Cargo.lock
+++ b/src/prodbg/core/Cargo.lock
@@ -3,7 +3,6 @@ name = "core"
 version = "0.1.0"
 dependencies = [
  "dynamic_reload 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "minifb 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 2.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -233,7 +232,6 @@ version = "0.1.0"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/prodbg/core/Cargo.toml
+++ b/src/prodbg/core/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Daniel Collin <daniel@collin.com>"]
 
 [dependencies]
 notify = "^2.5.0"
-libc = "0.2.0"
 libloading = "0.2.0"
 tempdir = "0.3"
 minifb = "0.7.1"

--- a/src/prodbg/core/src/backend_plugin.rs
+++ b/src/prodbg/core/src/backend_plugin.rs
@@ -1,4 +1,4 @@
-use libc::{c_void};
+use std::os::raw::{c_void};
 use std::rc::Rc;
 use plugin::Plugin;
 use plugins::PluginHandler;

--- a/src/prodbg/core/src/lib.rs
+++ b/src/prodbg/core/src/lib.rs
@@ -1,5 +1,4 @@
 extern crate minifb;
-extern crate libc;
 extern crate notify;
 extern crate dynamic_reload;
 extern crate prodbg_api;

--- a/src/prodbg/core/src/menus.rs
+++ b/src/prodbg/core/src/menus.rs
@@ -1,4 +1,4 @@
-use libc::{c_char, c_void, c_uint};
+use std::os::raw::{c_char, c_void, c_uint};
 use prodbg_api::{CMenuFuncs1, PDMenuItem};
 use std::ffi::CStr;
 use std::mem::transmute;

--- a/src/prodbg/core/src/plugin.rs
+++ b/src/prodbg/core/src/plugin.rs
@@ -4,7 +4,7 @@
 ///!
 
 use dynamic_reload::Lib;
-use libc::{c_char, c_void};
+use std::os::raw::{c_char, c_void};
 use std::rc::Rc;
 use std::mem::transmute;
 use std::ffi::CStr;

--- a/src/prodbg/core/src/plugin_io.rs
+++ b/src/prodbg/core/src/plugin_io.rs
@@ -1,4 +1,4 @@
-use libc::{c_void, c_char};
+use std::os::raw::{c_char, c_void};
 use prodbg_api::io::{CPDLoadState, CPDSaveState, LoadState};
 use prodbg_api::cfixed_string::CFixedString;
 use std::ffi::CStr;

--- a/src/prodbg/core/src/plugins.rs
+++ b/src/prodbg/core/src/plugins.rs
@@ -1,12 +1,11 @@
 extern crate libloading;
 extern crate dynamic_reload;
-extern crate libc;
 
 use self::dynamic_reload::{DynamicReload, Lib, PlatformName, UpdateState};
 use self::libloading::Result as LibRes;
 use self::libloading::Symbol;
 use std::rc::Rc;
-use self::libc::{c_char, c_void};
+use std::os::raw::{c_char, c_void};
 use std::mem::transmute;
 use plugin::Plugin;
 use std::cell::RefCell;

--- a/src/prodbg/core/src/services.rs
+++ b/src/prodbg/core/src/services.rs
@@ -1,4 +1,4 @@
-use libc::{c_void, c_char, c_uchar};
+use std::os::raw::{c_void, c_char, c_uchar};
 use std::ffi::CStr;
 use std::ptr;
 

--- a/src/prodbg/core/src/session.rs
+++ b/src/prodbg/core/src/session.rs
@@ -3,7 +3,7 @@ use prodbg_api::backend::{CBackendCallbacks};
 use plugins::PluginHandler;
 use reader_wrapper::{ReaderWrapper, WriterWrapper};
 use backend_plugin::{BackendHandle, BackendPlugins};
-use libc::{c_void};
+use std::os::raw::{c_void};
 use prodbg_api::events::*;
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]

--- a/src/prodbg/core/src/view_plugins.rs
+++ b/src/prodbg/core/src/view_plugins.rs
@@ -1,11 +1,11 @@
 use prodbg_api::view::CViewCallbacks;
-use libc::{c_void, c_uchar};
 use std::rc::Rc;
 use plugin::Plugin;
 use plugins::PluginHandler;
 use dynamic_reload::Lib;
 use session::SessionHandle;
 use std::ptr;
+use std::os::raw::{c_void, c_uchar};
 use prodbg_api::ui::Ui;
 use plugin_io;
 

--- a/src/prodbg/imgui_sys/Cargo.lock
+++ b/src/prodbg/imgui_sys/Cargo.lock
@@ -16,16 +16,10 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "libc"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "prodbg_api"
 version = "0.1.0"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/src/prodbg/main/Cargo.lock
+++ b/src/prodbg/main/Cargo.lock
@@ -6,7 +6,6 @@ dependencies = [
  "core 0.1.0",
  "imgui_sys 0.1.0",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "minifb 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prodbg_api 0.1.0",
@@ -17,7 +16,6 @@ dependencies = [
 name = "bgfx_rs"
 version = "0.1.0"
 dependencies = [
- "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "prodbg_api 0.1.0",
 ]
 
@@ -46,7 +44,6 @@ name = "core"
 version = "0.1.0"
 dependencies = [
  "dynamic_reload 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "minifb 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 2.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -300,7 +297,6 @@ version = "0.1.0"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/prodbg/main/Cargo.toml
+++ b/src/prodbg/main/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Daniel Collin <daniel@collin.com>"]
 build = "../build.rs"
 
 [dependencies]
-libc = "0.2.0"
 libloading = "0.2.0"
 lazy_static = "0.1.*"
 minifb = "0.7.1"

--- a/src/prodbg/main/src/docking.rs
+++ b/src/prodbg/main/src/docking.rs
@@ -1,4 +1,3 @@
-//use libc::{c_void, c_uchar};
 use std::rc::Rc;
 use core::plugin::Plugin;
 use core::plugins::PluginHandler;

--- a/src/prodbg/main/src/main.rs
+++ b/src/prodbg/main/src/main.rs
@@ -1,5 +1,4 @@
 extern crate core;
-extern crate libc;
 extern crate minifb;
 extern crate prodbg_api;
 extern crate bgfx_rs;

--- a/src/prodbg/main/src/windows.rs
+++ b/src/prodbg/main/src/windows.rs
@@ -3,7 +3,6 @@ extern crate bgfx_rs;
 extern crate viewdock;
 
 use bgfx_rs::Bgfx;
-use libc::{c_void, c_int};
 use minifb::{Scale, WindowOptions, MouseMode, MouseButton, Key, KeyRepeat};
 use core::view_plugins::{ViewHandle, ViewPlugins, ViewInstance};
 use core::backend_plugin::{BackendPlugins};
@@ -14,6 +13,7 @@ use menu::*;
 use imgui_sys::Imgui;
 use prodbg_api::ui_ffi::{PDVec2, ImguiKey};
 use prodbg_api::view::CViewCallbacks;
+use std::os::raw::{c_void, c_int};
 //use std::mem::transmute;
 
 const WIDTH: usize = 1280;

--- a/src/prodbg/ui_testbench/Cargo.lock
+++ b/src/prodbg/ui_testbench/Cargo.lock
@@ -6,7 +6,6 @@ dependencies = [
  "core 0.1.0",
  "imgui_sys 0.1.0",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "minifb 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prodbg_api 0.1.0",
 ]
@@ -15,7 +14,6 @@ dependencies = [
 name = "bgfx_rs"
 version = "0.1.0"
 dependencies = [
- "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "prodbg_api 0.1.0",
 ]
 
@@ -44,7 +42,6 @@ name = "core"
 version = "0.1.0"
 dependencies = [
  "dynamic_reload 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "minifb 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 2.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -261,7 +258,6 @@ version = "0.1.0"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/prodbg/ui_testbench/Cargo.toml
+++ b/src/prodbg/ui_testbench/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Daniel Collin <daniel@collin.com>"]
 build = "../build.rs"
 
 [dependencies]
-libc = "0.2.0"
 minifb = "0.7.1"
 lazy_static = "0.1.*"
 core = { path = "../core" }

--- a/src/prodbg/ui_testbench/src/main.rs
+++ b/src/prodbg/ui_testbench/src/main.rs
@@ -1,5 +1,4 @@
 extern crate core;
-extern crate libc;
 extern crate minifb;
 extern crate prodbg_api;
 extern crate bgfx_rs;
@@ -7,7 +6,7 @@ extern crate imgui_sys;
 
 use core::{DynamicReload, Search};
 use minifb::{Window, Key, Scale, WindowOptions, MouseMode, MouseButton};
-use libc::{c_void};
+use std::os::raw::{c_void};
 use prodbg_api::view::CViewCallbacks;
 //use prodbg_api::ui::Ui;
 use prodbg_api::ui_ffi::{PDVec2};


### PR DESCRIPTION
This does pretty much what the issue requires!

However I have doubts if in api/rust/prodbg/src/read_write.rs the alternative types to uint32_t, uint64_t etc. are not going to be problematic. std::os::raw does not define them and the ones that are supplied are (probably?) not guaranteed to be of constant width. Let me know if it's fine the way it is or if we'd rather want to replace them outright with u32, u64 etc.