### PR TITLE
Fixed first split. It now works properly for horizontal and vertical split

### DIFF
--- a/src/prodbg/viewdock/src/lib.rs
+++ b/src/prodbg/viewdock/src/lib.rs
@@ -234,15 +234,11 @@ impl Split {
     }
 
     pub fn no_split(&mut self, direction: Direction, dock_handle: DockHandle) -> bool {
-        // hack!
-        if self.direction == Direction::Full {
-            self.direction = direction;
-        }
-
         if self.is_left_zero_and_none() {
             //println!("no_split: is_left_zero_and_none");
             self.left_docks.docks.push(Dock::new(dock_handle));
             self.adjust_ratio_after_add();
+            self.direction = direction;
             return true;
         }
 
@@ -250,6 +246,7 @@ impl Split {
             //println!("no_split: is_right_zero_and_none");
             self.right_docks.docks.push(Dock::new(dock_handle));
             self.adjust_ratio_after_add();
+            self.direction = direction;
             return true;
         }
 


### PR DESCRIPTION
Fixes #181.
Hacky function no_split checks if Split is actually a split or just an empty mock with no or single Docks. If it has no Docks (direction==Direction::Full), it sets needed direction. However, if Split contains one Dock, this function forgets to change direction to needed. Since first Dock is created using Horizontal split (see windows.rs::show_popup_menu_no_splits), it is not changed when second Dock is added.