### PR TITLE
Workspace undo functionality

### DIFF
--- a/src/prodbg/viewdock/src/area/mod.rs
+++ b/src/prodbg/viewdock/src/area/mod.rs
@@ -146,11 +146,11 @@ mod test {
             0.7,
             SplitHandle(513),
             Rect::new(17.0, 15.0, 100.0, 159.0),
-            Area::Container(Container::new(Dock::new(DockHandle(14)), Rect::default())),
-            Area::Container(Container::new(Dock::new(DockHandle(15)), Rect::default()))
+            Area::Container(Container::new(Dock::new(DockHandle(14), "test"), Rect::default())),
+            Area::Container(Container::new(Dock::new(DockHandle(15), "test2"), Rect::default()))
         ));
         let container = Area::Container(Container::new(
-            Dock::new(DockHandle(17)), Rect::new(1.0, 2.0, 3.0, 4.0)
+            Dock::new(DockHandle(17), "test"), Rect::new(1.0, 2.0, 3.0, 4.0)
         ));
         let split_serialized = serde_json::to_string(&split).unwrap();
         let container_serialized = serde_json::to_string(&container).unwrap();

--- a/src/prodbg/viewdock/src/area/split/mod.rs
+++ b/src/prodbg/viewdock/src/area/split/mod.rs
@@ -181,8 +181,8 @@ mod test {
             0.7,
             SplitHandle(513),
             Rect::new(17.0, 15.0, 100.0, 159.0),
-            Area::Container(Container::new(Dock::new(DockHandle(14)), Rect::default())),
-            Area::Container(Container::new(Dock::new(DockHandle(15)), Rect::default()))
+            Area::Container(Container::new(Dock::new(DockHandle(14), "test"), Rect::default())),
+            Area::Container(Container::new(Dock::new(DockHandle(15), "test2"), Rect::default()))
         );
 
         let serialized = serde_json::to_string(&split_in).unwrap();

--- a/src/prodbg/viewdock/src/dock/mod.rs
+++ b/src/prodbg/viewdock/src/dock/mod.rs
@@ -16,10 +16,10 @@ pub struct Dock {
 }
 
 impl Dock {
-    pub fn new(dock_handle: DockHandle) -> Dock {
+    pub fn new(dock_handle: DockHandle, plugin_name: &str) -> Dock {
         Dock {
             handle: dock_handle,
-            plugin_name: "".to_owned(),
+            plugin_name: plugin_name.to_owned(),
             plugin_data: None,
             rect: Rect::default(),
         }


### PR DESCRIPTION
Window.views now removes deleted plugin's handles properly
Added undo functionality (currently bound to 'Z' key)