### PR TITLE
Complete undo/redo for workspace states

### DIFF
--- a/src/prodbg/main/src/windows.rs
+++ b/src/prodbg/main/src/windows.rs
@@ -24,6 +24,7 @@ const WORKSPACE_UNDO_LIMIT: usize = 10;
 enum State {
     Default,
     Dragging(DragTarget, String),
+    DraggingNothing,
 }
 
 pub struct MouseState {
@@ -283,6 +284,16 @@ impl Window {
                     }
                 } else {
                     cursor = CursorStyle::Arrow;
+                    if self.win.get_mouse_down(MouseButton::Left) {
+                        next_state = Some(State::DraggingNothing);
+                    }
+                }
+            },
+
+            State::DraggingNothing => {
+                cursor = CursorStyle::Arrow;
+                if !self.win.get_mouse_down(MouseButton::Left) {
+                    next_state = Some(State::Default);
                 }
             },
 


### PR DESCRIPTION
Changes:
* added redo funcitonality;
* maximal number of states is defined by WORKSPACE_UNDO_LIMIT constant;
* changing slider positions in workspace are also saved (state is remembered on drag and saved on drop)
* added new "DraggingNothing" drag state to prevent possible interaction with Imgui drag-and-drop

Fixes #188.