### PR TITLE
Pack of changes for viewdock

### DIFF
--- a/src/native/ui/imgui_ffi.cpp
+++ b/src/native/ui/imgui_ffi.cpp
@@ -1618,6 +1618,14 @@ extern "C" int imgui_begin_float(const char* name, int show) {
     return s;
 }
 
+extern "C" void imgui_begin_child(const char* name, float h) {
+	ImGui::BeginChild(name, ImVec2(0, h), false, 0);
+}
+
+extern "C" void imgui_end_child() {
+	ImGui::EndChild();
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 extern "C" void imgui_end() {

--- a/src/prodbg/imgui_sys/src/lib.rs
+++ b/src/prodbg/imgui_sys/src/lib.rs
@@ -79,12 +79,24 @@ impl Imgui {
         }
     }
 
-    //+Z
     pub fn begin_window_float(name: &str, show: bool) -> bool {
         unsafe {
             let t = CFixedString::from_str(name).as_ptr();
             if imgui_begin_float(t, show as c_uchar) == 1 { true } else { false }
         }
+    }
+
+    pub fn begin_window_child(name: &str, height: f32) {
+    	unsafe {
+            let t = CFixedString::from_str(name).as_ptr();
+            imgui_begin_child(t, height);
+    	}
+    }
+
+    pub fn end_window_child() {
+    	unsafe {
+    		imgui_end_child();
+    	} 
     }
 
     pub fn map_key(key_target: usize, key_source: usize) {
@@ -168,9 +180,10 @@ impl Imgui {
 
 extern "C" {
     fn imgui_begin(name: *const c_char, show: c_uchar) -> c_int;
-    //+Z
     fn imgui_begin_float(name: *const c_char, show: c_uchar) -> c_int;
     fn imgui_end();
+    fn imgui_begin_child(name: *const c_char, h: f32);
+    fn imgui_end_child();
     fn imgui_create_ui_funcs() -> *mut CPdUI;
     fn imgui_get_ui_funcs() -> *mut CPdUI;
     fn imgui_set_window_pos(x: f32, y: f32);
@@ -181,7 +194,6 @@ extern "C" {
     fn imgui_set_mouse_state(index: i32, state: c_int);
     fn imgui_clear_keys();
     fn imgui_set_key_down(key: i32);
-    //+Z
     fn imgui_tab(label: *const c_char, selected: bool, last: bool) -> c_int;
     fn imgui_separator();
     fn imgui_tab_pos() -> f32;

--- a/src/prodbg/viewdock/src/area/mod.rs
+++ b/src/prodbg/viewdock/src/area/mod.rs
@@ -164,7 +164,7 @@ impl Area {
 }
 
 #[derive(Debug)]
-pub struct SizerPos(pub SplitHandle, pub usize, pub Direction);
+pub struct SizerPos(pub SplitHandle, pub usize, pub Direction, pub f32);
 
 
 #[cfg(test)]

--- a/src/prodbg/viewdock/src/area/split/mod.rs
+++ b/src/prodbg/viewdock/src/area/split/mod.rs
@@ -67,7 +67,7 @@ impl Split {
         let sizer_rects = self.rect.area_around_splits(self.direction, &self.ratios[0..self.ratios.len() - 1], 8.0);
         return sizer_rects.iter().enumerate()
             .find(|&(_, rect)| rect.point_is_inside(pos))
-            .map(|(i, _)| SizerPos(self.handle, i, self.direction));
+            .map(|(i, _)| SizerPos(self.handle, i, self.direction, self.ratios[i]));
     }
 
     pub fn map_rect_to_delta(&self, delta: (f32, f32)) -> f32 {
@@ -77,20 +77,13 @@ impl Split {
         }
     }
 
-    pub fn change_ratio(&mut self, index: usize, delta: (f32, f32)) {
+    pub fn change_ratio(&mut self, index: usize, origin: f32, delta: (f32, f32)) {
         let scale = Self::map_rect_to_delta(self, delta);
-        let max = if index < self.ratios.len() - 1 {
-            self.ratios[index + 1]
-        } else {
-            1.0
-        };
-        let min = if index > 0 {
-            self.ratios[index - 1]
-        } else {
-            0.0
-        };
-        let mut res = self.ratios[index] + scale;
+        let mut res = origin + scale;
 
+        let min = if index==0 {0.05} else {self.ratios[index-1]+0.05};
+        let max = if index==self.ratios.len()-1 {0.95} else {self.ratios[index+1]-0.05};
+        
         if res < min {
             res = min;
         }

--- a/src/prodbg/viewdock/src/lib.rs
+++ b/src/prodbg/viewdock/src/lib.rs
@@ -118,13 +118,21 @@ impl Workspace {
         }
     }
 
-    // TODO: use absolute coordinates here
-    pub fn change_split_ratio(&mut self, handle: SplitHandle, index: usize, delta: (f32, f32)) {
+    pub fn change_ratio(&mut self, handle: SplitHandle, index: usize, origin:f32, delta: (f32, f32)) {
         if let Some(ref mut root) = self.root_area {
             if let Some(s) = root.get_split_by_handle(handle) {
-                s.change_ratio(index, delta);
+                s.change_ratio(index, origin, delta);
             }
         }
+    }
+
+    pub fn get_ratio(&mut self, handle: SplitHandle, index: usize) -> f32 {
+        if let Some(ref mut root) = self.root_area {
+            if let Some(s) = root.get_split_by_handle(handle) {
+                return s.ratios[index];
+            }
+        }
+        0.0
     }
 
     pub fn get_sizer_at_pos(&self, pos: (f32, f32)) -> Option<SizerPos> {


### PR DESCRIPTION
Tabs are now not scrollable
Fixed undo/redo for split sizer changes (fixes #221)
PreDragging state now uses absolute mouse coordinates change to start dragging
Changing ratios is a bit more user-friendly now
Dock move overlay is now shown even if it does not do anythin (fixes #224, #220)