### PR TITLE
Fixed Ui::calc_text_size

### DIFF
--- a/api/rust/prodbg/src/ui.rs
+++ b/api/rust/prodbg/src/ui.rs
@@ -335,12 +335,13 @@ impl Ui {
     #[inline]
     pub fn calc_text_size(&self, text: &str, offset: usize) -> (f32, f32) {
         unsafe {
+            let start = CFixedString::from_str(text);
             if offset == 0 {
-                let t = ((*self.api).calc_text_size)(text.as_ptr(), ptr::null(), 0, -1.0);
+                let t = ((*self.api).calc_text_size)(start.as_ptr(), ptr::null(), 0, -1.0);
                 (t.x, t.y)
             } else {
-                let slice = &text[offset..];
-                let t = ((*self.api).calc_text_size)(text.as_ptr(), slice.as_ptr(), 0, -1.0);
+                let slice = &start.as_str()[offset..];
+                let t = ((*self.api).calc_text_size)(start.as_ptr(), slice.as_ptr(), 0, -1.0);
                 (t.x, t.y)
             }
         }

--- a/api/rust/prodbg/src/ui_ffi.rs
+++ b/api/rust/prodbg/src/ui_ffi.rs
@@ -274,7 +274,7 @@ pub struct CPdUI {
 	pub get_frame_count: *mut extern fn () -> c_int,
 	pub get_style_col_name: extern fn(c_uint) -> *const c_char,
 	pub calc_item_rect_closest_point: extern fn(PDVec2, c_int, c_float) -> PDVec2,
-	pub calc_text_size: extern fn(*const u8, *const u8, c_int, c_float) -> PDVec2,
+	pub calc_text_size: extern fn(*const c_char, *const u8, c_int, c_float) -> PDVec2,
 	pub calc_list_clipping: extern fn(c_int, c_float, *mut c_int, *mut c_int),
 	pub begin_child_frame: extern fn(c_uint, PDVec2) -> c_int,
 	pub end_child_frame: *mut extern fn () -> c_void,


### PR DESCRIPTION
It now passes correct null-ended string to ImGui.