### PR TITLE
No crash when window height is 0

### DIFF
--- a/src/prodbg/main/src/windows.rs
+++ b/src/prodbg/main/src/windows.rs
@@ -595,7 +595,7 @@ impl Window {
         let mut has_shown_menu = 0u32;
 
         let mut win_size = self.win.get_size();
-        win_size.1 -= self.statusbar.get_size() as usize;
+        win_size.1 = win_size.1.saturating_sub(self.statusbar.get_size() as usize);
 
         let mouse = self.win.get_mouse_pos(MouseMode::Clamp).unwrap_or((0.0, 0.0));
 


### PR DESCRIPTION
Small fix to #260. Does not solve problem but fixes crash.