### PR TITLE
First set of changes for #257

### DIFF
--- a/src/prodbg/viewdock/src/area/container/mod.rs
+++ b/src/prodbg/viewdock/src/area/container/mod.rs
@@ -196,7 +196,7 @@ mod test {
     use rect::Rect;
 
     fn get_test_dock(id: u64) -> Dock {
-        return Dock::new(DockHandle(id), "test");
+        return Dock::new(DockHandle(id), "test_name", "test_plugin");
     }
 
     fn get_test_container() -> Container {
@@ -294,6 +294,7 @@ mod test {
         let container_in = Container {
             docks: vec![Dock {
                 handle: DockHandle(1),
+                name: "regs".to_owned(),
                 plugin_name: "registers".to_owned(),
                 plugin_data: Some(vec!["some_data".to_owned(), "more_data".to_owned()]),
             }],

--- a/src/prodbg/viewdock/src/area/mod.rs
+++ b/src/prodbg/viewdock/src/area/mod.rs
@@ -197,11 +197,11 @@ mod test {
             0.7,
             SplitHandle(513),
             Rect::new(17.0, 15.0, 100.0, 159.0),
-            Area::Container(Container::new(Dock::new(DockHandle(14), "test"), Rect::default())),
-            Area::Container(Container::new(Dock::new(DockHandle(15), "test2"), Rect::default()))
+            Area::Container(Container::new(Dock::new(DockHandle(14), "test", "plugin"), Rect::default())),
+            Area::Container(Container::new(Dock::new(DockHandle(15), "test2", "plugin"), Rect::default()))
         ));
         let container = Area::Container(Container::new(
-            Dock::new(DockHandle(17), "test"), Rect::new(1.0, 2.0, 3.0, 4.0)
+            Dock::new(DockHandle(17), "test", "plugin"), Rect::new(1.0, 2.0, 3.0, 4.0)
         ));
         let split_serialized = serde_json::to_string(&split).unwrap();
         let container_serialized = serde_json::to_string(&container).unwrap();

--- a/src/prodbg/viewdock/src/area/split/mod.rs
+++ b/src/prodbg/viewdock/src/area/split/mod.rs
@@ -218,8 +218,8 @@ mod test {
             0.7,
             SplitHandle(513),
             Rect::new(17.0, 15.0, 100.0, 159.0),
-            Area::Container(Container::new(Dock::new(DockHandle(14), "test"), Rect::default())),
-            Area::Container(Container::new(Dock::new(DockHandle(15), "test2"), Rect::default()))
+            Area::Container(Container::new(Dock::new(DockHandle(14), "test", "viewer"), Rect::default())),
+            Area::Container(Container::new(Dock::new(DockHandle(15), "test2", "viewer"), Rect::default()))
         );
 
         let serialized = serde_json::to_string(&split_in).unwrap();

--- a/src/prodbg/viewdock/src/dock/mod.rs
+++ b/src/prodbg/viewdock/src/dock/mod.rs
@@ -8,14 +8,16 @@ pub struct DockHandle(pub u64);
 #[derive(Debug, Clone)]
 pub struct Dock {
     pub handle: DockHandle,
+    pub name: String,
     pub plugin_name: String,
     pub plugin_data: Option<Vec<String>>,
 }
 
 impl Dock {
-    pub fn new(dock_handle: DockHandle, plugin_name: &str) -> Dock {
+    pub fn new(handle: DockHandle, name: &str, plugin_name: &str) -> Dock {
         Dock {
-            handle: dock_handle,
+            handle: handle,
+            name: name.to_owned(),
             plugin_name: plugin_name.to_owned(),
             plugin_data: None,
         }
@@ -40,6 +42,7 @@ mod test {
     fn test_dock_serialize_0() {
         let dock_in = Dock {
             handle: DockHandle(1),
+            name: "checker".to_owned(),
             plugin_name: "disassembly".to_owned(),
             plugin_data: None,
         };
@@ -48,6 +51,7 @@ mod test {
         let dock_out: Dock = serde_json::from_str(&serialized).unwrap();
 
         assert_eq!(dock_in.handle, dock_out.handle);
+        assert_eq!(dock_in.name, dock_out.name);
         assert_eq!(dock_in.plugin_name, dock_out.plugin_name);
         assert_eq!(dock_in.plugin_data, dock_out.plugin_data);
     }
@@ -56,6 +60,7 @@ mod test {
     fn test_dock_serialize_1() {
         let dock_in = Dock {
             handle: DockHandle(1),
+            name: "regs".to_owned(),
             plugin_name: "registers".to_owned(),
             plugin_data: Some(vec!["some_data".to_owned(), "more_data".to_owned()]),
         };

--- a/src/prodbg/viewdock/src/dock/serialize.rs
+++ b/src/prodbg/viewdock/src/dock/serialize.rs
@@ -18,6 +18,7 @@ struct DockMapVisitor<'a> {
 impl<'a> serde::ser::MapVisitor for DockMapVisitor<'a> {
     fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error> where S: serde::Serializer {
         try!(serializer.serialize_struct_elt("handle", &self.value.handle));
+        try!(serializer.serialize_struct_elt("name", &self.value.name));
         try!(serializer.serialize_struct_elt("plugin_name", &self.value.plugin_name));
         try!(serializer.serialize_struct_elt("plugin_data", &self.value.plugin_data));
         Ok(None)
@@ -27,6 +28,7 @@ impl<'a> serde::ser::MapVisitor for DockMapVisitor<'a> {
 // Deserialization
 gen_struct_deserializer!(Dock;
     handle => "handle", Handle,
+    name => "name", Name,
     plugin_name => "plugin_name", PluginName,
     plugin_data => "plugin_data", PluginData;
 );

--- a/src/prodbg/viewdock/src/lib.rs
+++ b/src/prodbg/viewdock/src/lib.rs
@@ -375,8 +375,8 @@ impl Workspace {
 
     /// Creates workspace from serialized string. Since `Rect` fields are not serialized, call
     /// `update_rect` to set new one.
-    pub fn from_state(state: &str) -> Workspace {
-        serde_json::from_str(state).unwrap()
+    pub fn from_state(state: &str) -> Result<Workspace, serde_json::Error> {
+        serde_json::from_str(state)
     }
 
     /// Returns all the docks in this structure
@@ -413,7 +413,7 @@ mod test {
     use test_helper::{is_container_with_single_dock, rects_are_equal};
 
     fn test_area_container(id: u64) -> Area {
-        Area::Container(Container::new(Dock::new(DockHandle(id), "test"), Rect::default()))
+        Area::Container(Container::new(Dock::new(DockHandle(id), "test", "plugin"), Rect::default()))
     }
 
     fn test_area_split(dir: Direction, id: u64, first: Area, second: Area) -> Area {
@@ -504,7 +504,7 @@ mod test {
             handle_counter: SplitHandle(0)
         };
         let target = ItemTarget::SplitRoot(Direction::Horizontal, 0);
-        ws.create_dock_at(target, Dock::new(DockHandle(6), "test2"));
+        ws.create_dock_at(target, Dock::new(DockHandle(6), "test2", "plugin"));
         match ws.root_area.unwrap() {
             Area::Split(ref s) => {
                 assert_eq!(s.children.len(), 2);
@@ -523,7 +523,7 @@ mod test {
             handle_counter: SplitHandle(0)
         };
         let target = ItemTarget::SplitRoot(Direction::Vertical, 1);
-        ws.create_dock_at(target, Dock::new(DockHandle(6), "test2"));
+        ws.create_dock_at(target, Dock::new(DockHandle(6), "test2", "plugin"));
         match ws.root_area.unwrap() {
             Area::Split(ref s) => {
                 assert_eq!(s.children.len(), 2);
@@ -545,7 +545,7 @@ mod test {
             handle_counter: SplitHandle(1),
         };
         let target = ItemTarget::SplitContainer(SplitHandle(0), 0, 1);
-        ws.create_dock_at(target, Dock::new(DockHandle(2), "test2"));
+        ws.create_dock_at(target, Dock::new(DockHandle(2), "test2", "plugin"));
         match ws.root_area.unwrap() {
             Area::Split(ref s) => {
                 assert_eq!(s.direction, Direction::Horizontal);
@@ -576,7 +576,7 @@ mod test {
             handle_counter: SplitHandle(1),
         };
         let target = ItemTarget::SplitDock(DockHandle(1), Direction::Horizontal, 1);
-        ws.create_dock_at(target, Dock::new(DockHandle(2), "test2"));
+        ws.create_dock_at(target, Dock::new(DockHandle(2), "test2", "plugin"));
         match ws.root_area.unwrap() {
             Area::Split(ref s) => {
                 assert_eq!(s.children.len(), 3);
@@ -599,7 +599,7 @@ mod test {
             handle_counter: SplitHandle(1),
         };
         let target = ItemTarget::SplitDock(DockHandle(0), Direction::Vertical, 0);
-        ws.create_dock_at(target, Dock::new(DockHandle(2), "test2"));
+        ws.create_dock_at(target, Dock::new(DockHandle(2), "test2", "plugin"));
         match ws.root_area.unwrap() {
             Area::Split(ref s) => {
                 assert_eq!(s.direction, Direction::Horizontal);
@@ -638,7 +638,7 @@ mod test {
     fn test_workspace_serialize_1() {
         let ws_in = Workspace {
             root_area: Some(Area::Container(
-                Container::new(Dock::new(DockHandle(5), "test"), Rect::default())
+                Container::new(Dock::new(DockHandle(5), "test", "plugin"), Rect::default())
             )),
             rect: Rect::new(4.0, 5.0, 2.0, 8.0),
             handle_counter: SplitHandle(2),


### PR DESCRIPTION
Changes:
Dock names are generated as `PluginTypeName`, `PluginTypeName 2`, etc instead of `Plugin 0`, `Plugin 1`
Dock names are saved in layout now

Plugins do not hold any kind of counter. Instead, dock name generation starts with "PluginType", "PluginType 2" and so on until it finds unique name.
Plugin names are saved to layout now so they are persistent across runs. Also, this will make implementing custom dock names easier.