### PR TITLE
Fixed menu name for "New project..." sub-menu on linux

### DIFF
--- a/src/prodbg/main/src/windows/mod.rs
+++ b/src/prodbg/main/src/windows/mod.rs
@@ -119,7 +119,7 @@ impl Windows {
 
     fn add_backend_menus(window: &mut Window, backend_plugins: Vec<String>) {
         // Build menu with all the backend plugins
-        let mut backend_menus = minifb::Menu::new("").unwrap();
+        let mut backend_menus = minifb::Menu::new("New Project...").unwrap();
 
         for (i, name) in backend_plugins.iter().enumerate() {
             let id = MENU_FILE_BACKEND_START + i;


### PR DESCRIPTION
Right now there are two places for sub-menu name: either `UnixMenuItem.label` or `UnixMenuItem.sub_menu.name`. Maybe menus struct should be changed to prevent such ambiguity?