### PR TITLE
Ui::text does not copy strings

### DIFF
--- a/api/rust/prodbg/src/ui.rs
+++ b/api/rust/prodbg/src/ui.rs
@@ -691,8 +691,9 @@ impl Ui {
 
     pub fn text(&self, text: &str) {
         unsafe {
-            let t = CFixedString::from_str(text).as_ptr();
-            ((*self.api).text)(t);
+            let start = text.as_ptr() as *const i8;
+            let end = start.offset(text.len() as isize);
+            ((*self.api).text_unformatted)(start, end);
         }
     }
 


### PR DESCRIPTION
We can just pass pointers to the start and to the end of string instead of copying it and adding null at the end