### PR TITLE
Basic request_ids

### DIFF
--- a/api/include/pd_readwrite.h
+++ b/api/include/pd_readwrite.h
@@ -88,19 +88,22 @@ typedef struct PDWriter {
     /**
      * This starts to write an event. An event is usually of the type PDEventType that can be
      * used to compunicate back to the debugger. There is usually (but not always) a pair
-     * of get/setEvents and it's the plugins resposibilty to reply back with data when
+     * of get/set event and it's the plugins resposibilty to reply back with data when
      * there is a request from the debugger
      *
      * @param writer writer object.
-     * @param event Id of the event. This usually a PDEventType
+     * @param event Identifier of the event. This usually a PDEventType
+     *
+     * @return Request_id. This is is storted as "request_id" with the reply and can be used
+     * to pair up and request. 0 means invalid something went wrong.
      *
      * \code
-     * PDWrite_event_begin(writer, PDEvent_setBreakpoint);
+     * uint64_t request_id PDWrite_event_begin(writer, PDEvent_setBreakpoint);
      * ...
      * PDWrite_event_end();
      * \endcode
      */
-    PDWriteStatus (*write_event_begin)(struct PDWriter* writer, uint16_t event);
+    uint64_t (*write_event_begin)(struct PDWriter* writer, uint16_t event);
 
     /**
      * This ends an event. Notice that PDWrite_beginEvent needs to be started first

--- a/api/rust/prodbg/src/read_write.rs
+++ b/api/rust/prodbg/src/read_write.rs
@@ -344,7 +344,7 @@ macro_rules! write_fun {
 impl Writer {
     pub fn event_begin(&mut self, event: u16) -> u64 {
         unsafe {
-            ((*self.api).write_event_begin)(transmute(self.api), event);
+            ((*self.api).write_event_begin)(transmute(self.api), event)
         }
     }
 

--- a/api/rust/prodbg/src/read_write.rs
+++ b/api/rust/prodbg/src/read_write.rs
@@ -97,7 +97,7 @@ pub enum WriteStatus {
 #[repr(C)]
 pub struct CPDWriterAPI {
     private_data: *mut c_void,
-    pub write_event_begin: extern "C" fn(writer: *mut c_void, event: c_ushort) -> WriteStatus,
+    pub write_event_begin: extern "C" fn(writer: *mut c_void, event: c_ushort) -> u64,
     pub write_event_end: extern "C" fn(writer: *mut c_void) -> WriteStatus,
     pub write_header_array_begin: extern "C" fn(writer: *mut c_void, ids: *mut *const c_char)
                                                 -> WriteStatus,
@@ -342,7 +342,7 @@ macro_rules! write_fun {
 }
 
 impl Writer {
-    pub fn event_begin(&mut self, event: u16) {
+    pub fn event_begin(&mut self, event: u16) -> u64 {
         unsafe {
             ((*self.api).write_event_begin)(transmute(self.api), event);
         }


### PR DESCRIPTION
This adds basic request ids as outlined here https://github.com/emoon/ProDBG/issues/256

The way this works is when doing `event_begin` an u64 id will be returned.  an a "_request_id" will be written to the event. Basic usage is that

Request code

```Rust
request_id = writer.event_begin(GET_MEMORY);
...
// event loop
match event {
  SET_MEMORY => {
   if request_id == event.find_u64("_reply_request") {
    ...
  }
} 
```

Send code

```Rust
request_id = reader.find_u64("_request_id");
// .. do stuff
writer.event_begin(SET_MEMORY)
writer.write_u64("_reply_request", request_id);
```

So this is fairly manual but still better than nothing until we work out a better API.

cc @SlNPacifist 

